### PR TITLE
Package Updates, minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##mean-wreed 0.3.0
+##mean-wreed 0.3.1
 wreetco MEAN seed
 
 ##about

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 // app.js
 var app_info = {
 	name: "MEAN Wreed",
-	version: "0.3.0"
+	version: "0.3.1"
 };
 
 // app includes

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "MEAN Wreed",
-  "version": "0.3.0",
+  "name": "mean-wreed",
+  "version": "0.3.1",
   "dependencies": {
     "angular": "latest",
     "angular-route": "latest"

--- a/config/db.js
+++ b/config/db.js
@@ -1,7 +1,7 @@
 var mongoose = require("mongoose");
 
 module.exports = function(db) {
-	mongoose.connect('mongodb://localhost/' + db, {}, function(err) {
+	mongoose.connect('mongodb://127.0.0.1/' + db, {}, function(err) {
 		if (err)	{
 			console.log("[!] Database error: " + err);	
 		}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
 	"name": "MEAN-Wreed",
 	"main": "app.js",
 	"dependencies": {
-		"express" : "~4.13.4",
-		"mongoose" : "~4.4.11",
-		"method-override" : "~2.3.5"        
-	}
+		"express" : "~4.14.0",
+		"mongoose" : "~4.6.3",
+		"method-override" : "~2.3.6"        
+	},
+	"repository" : { 
+		"type" : "git",
+		"url" : "https://github.com/wreetco/mean-wreed.git"
+  	},
+	"license" : "MIT"
 }


### PR DESCRIPTION
- Fixed NPM warnings (proper repo and license fields in package.json)
- Fixed Bower warnings (proper syntax in bower.json)
- Updated Packages (express, mongoose, method-override)
- Mongoose connect uses 127.0.0.1 instead of localhost
